### PR TITLE
Fix telemetry build error

### DIFF
--- a/Core/Src/telemetry.c
+++ b/Core/Src/telemetry.c
@@ -7,6 +7,7 @@
 
 
 #include "telemetry.h"
+#include "stm32h7xx_hal.h"
 // UART handle for telemetry output (defined in main.c or elsewhere)
 extern UART_HandleTypeDef huart3;
 


### PR DESCRIPTION
## Summary
- include the STM32 HAL headers so `HAL_MAX_DELAY` is defined

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850223bacdc8330922ae64331684aa2