### PR TITLE
Fix duplicate include in rc_input.c

### DIFF
--- a/Core/Src/rc_input.c
+++ b/Core/Src/rc_input.c
@@ -11,7 +11,6 @@
 #include "rc_input.h"
 #include "stm32h7xx_hal.h"
 #include <string.h>    // for memset
-#include <string.h>    // for memset
 #include <stdlib.h>    // for abs()
 
 static uint32_t lastSYNC;


### PR DESCRIPTION
## Summary
- remove a duplicate `string.h` include from `rc_input.c`

## Testing
- `echo "No tests configured"`

------
https://chatgpt.com/codex/tasks/task_e_685041ef299083309a4240d3680a1829