### PR TITLE
Add debug bypass for pre-arm health checks

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -152,6 +152,10 @@ void Error_Handler(void);
 
 /* USER CODE BEGIN Private defines */
 
+/* Define DEBUG_BYPASS_HEALTH to skip pre-arm health checks and run the
+ * debug menu immediately. Enable via compiler flag or uncomment below. */
+/* #define DEBUG_BYPASS_HEALTH */
+
 /* USER CODE END Private defines */
 
 #ifdef __cplusplus

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -205,6 +205,7 @@ int main(void)
 
 
 
+#ifndef DEBUG_BYPASS_HEALTH
   // 4) Pre‐arm Calibration (Power ON → IMU level & bias)
 
   // In pre‐arm calibrations:
@@ -507,11 +508,13 @@ int main(void)
           }
       }
 
-      if (prearmOK) {
-          FlightState_Arm();
-          HAL_UART_Transmit(&huart1, (uint8_t*)"OK: Armed!\r\n", 12, HAL_MAX_DELAY);
-      }
+  if (prearmOK) {
+      FlightState_Arm();
+      HAL_UART_Transmit(&huart1, (uint8_t*)"OK: Armed!\r\n", 12, HAL_MAX_DELAY);
   }
+}
+
+#endif // DEBUG_BYPASS_HEALTH
 
   /* USER CODE END 2 */
 


### PR DESCRIPTION
## Summary
- add a disabled `DEBUG_BYPASS_HEALTH` macro in `main.h`
- wrap pre-arm calibration code in `main.c` with `#ifndef DEBUG_BYPASS_HEALTH`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685041b5a694833096bc26d64c24c7dc