### PR TITLE
Fix Motor_Init outside debug bypass block

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -236,6 +236,9 @@ int main(void)
   DebugMenu_Init(&huart1);
   DebugMsg("Initialization complete\r\n");
 
+  Motor_Init();      // ESC PWM outputs
+
+
 
 
 #ifndef DEBUG_BYPASS_HEALTH
@@ -480,7 +483,6 @@ int main(void)
   }
   DebugMsg("EKF sensor publish done\r\n");
   // —————————————————————————————————————————
-  Motor_Init();      // ESC PWM outputs
 
   // 11) EKF health pre‐check (if you have a ready‐made EKF routine)
   {


### PR DESCRIPTION
## Summary
- ensure Motor_Init() runs regardless of `DEBUG_BYPASS_HEALTH`

## Testing
- `make` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_6850f5c9c85483308b6efaf5a4ad521c