### PR TITLE
Interrupt-driven debug menu

### DIFF
--- a/Core/Inc/debug_menu.h
+++ b/Core/Inc/debug_menu.h
@@ -12,5 +12,6 @@
 
 void DebugMenu_Init(UART_HandleTypeDef *huart);
 void DebugMenu_Task(void);
+void DebugMenu_ForceInput(uint8_t ch);
 
 #endif // DEBUG_MENU_H

--- a/Core/Src/debug_menu.c
+++ b/Core/Src/debug_menu.c
@@ -19,18 +19,32 @@ static UART_HandleTypeDef *dbgUart;
 static char cmdBuf[32];
 static uint8_t cmdIdx;
 static uint32_t lastBeat;
+static volatile uint8_t rxByte;
+static volatile uint8_t rxPending;
+
+// Forward GPS byte handler so we can chain callbacks
+void GPS_UART_RxCpltCallback(UART_HandleTypeDef *huart);
+
+static void process_char(uint8_t ch);
 
 static void send(const char *s)
 {
     HAL_UART_Transmit(dbgUart, (uint8_t*)s, strlen(s), HAL_MAX_DELAY);
 }
 
+static void show_menu(void)
+{
+    send("\r\n--- Debug Menu ---\r\n");
+    send("h: help\r\ns: sensors\r\np: ppm\r\nb: buzzer test\r\n> ");
+}
+
 void DebugMenu_Init(UART_HandleTypeDef *huart)
 {
     dbgUart = huart;
     cmdIdx = 0;
-    send("\r\n--- Debug Menu ---\r\n");
-    send("h: help\r\ns: sensors\r\np: ppm\r\nb: buzzer test\r\n> ");
+    show_menu();
+    HAL_UART_Receive_IT(dbgUart, &rxByte, 1);
+    rxPending = 0;
 }
 
 static void show_help(void)
@@ -81,6 +95,20 @@ static void test_buzzer(void)
     Buzzer_Stop();
 }
 
+static void process_char(uint8_t ch)
+{
+    if (ch == '\r' || ch == '\n') {
+        if (cmdIdx > 0) {
+            handle_cmd();
+            cmdIdx = 0;
+        } else {
+            send("> ");
+        }
+    } else if (cmdIdx < sizeof(cmdBuf) - 1) {
+        cmdBuf[cmdIdx++] = (char)ch;
+    }
+}
+
 static void handle_cmd(void)
 {
     cmdBuf[cmdIdx] = '\0';
@@ -96,27 +124,38 @@ static void handle_cmd(void)
     send("> ");
 }
 
+void DebugMenu_ForceInput(uint8_t ch)
+{
+    process_char(ch);
+}
+
 void DebugMenu_Task(void)
 {
     uint32_t now = HAL_GetTick();
     if (now - lastBeat >= 1000) {
         char buf[32];
-        int len = snprintf(buf, sizeof(buf), "[%lu ms]\r\n> ", (unsigned long)now);
+        int len = snprintf(buf, sizeof(buf), "[%lu ms]\r\n", (unsigned long)now);
         HAL_UART_Transmit(dbgUart, (uint8_t*)buf, len, HAL_MAX_DELAY);
+        show_menu();
         lastBeat = now;
     }
-    uint8_t ch;
-    while(HAL_UART_Receive(dbgUart,&ch,1,0) == HAL_OK) {
-        if(ch=='\r' || ch=='\n') {
-            if(cmdIdx>0) {
-                handle_cmd();
-                cmdIdx=0;
-            } else {
-                send("> ");
-            }
-        } else if(cmdIdx < sizeof(cmdBuf)-1) {
-            cmdBuf[cmdIdx++] = (char)ch;
-        }
+
+    if (rxPending || rxByte != 0) {
+        uint8_t ch = rxByte;
+        rxPending = 0;
+        rxByte = 0;
+        process_char(ch);
     }
+}
+
+void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
+{
+    if (huart == dbgUart) {
+        rxPending = 1;
+        HAL_UART_Receive_IT(dbgUart, &rxByte, 1);
+    }
+
+    // Chain other modules that use UART receive interrupts
+    GPS_UART_RxCpltCallback(huart);
 }
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -570,7 +570,6 @@ int main(void)
   /* USER CODE BEGIN WHILE */
   while (1)
   {
-        DebugMsg("loop start\r\n");
 
         uint32_t now = HAL_GetTick();
 


### PR DESCRIPTION
## Summary
- change debug menu to use UART interrupt for input
- re-display the menu each second alongside the timer
- add optional forced command helper

## Testing
- `make` *(fails: No targets specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851781a17c88330b43b813442f9c184