### PR TITLE
Fix handle_cmd declaration

### DIFF
--- a/Core/Src/debug_menu.c
+++ b/Core/Src/debug_menu.c
@@ -26,6 +26,7 @@ static volatile uint8_t rxPending;
 void GPS_UART_RxCpltCallback(UART_HandleTypeDef *huart);
 
 static void process_char(uint8_t ch);
+static void handle_cmd(void);
 
 static void send(const char *s)
 {


### PR DESCRIPTION
## Summary
- prototype `handle_cmd` so it is known before use

## Testing
- `make` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_6851a46e828c83308ac68cfee5eeec73