### PR TITLE
Fix PPM timing normalization

### DIFF
--- a/Core/Src/rc_input.c
+++ b/Core/Src/rc_input.c
@@ -22,8 +22,9 @@ static uint16_t rssiValue;
 
 // Helper to get microseconds since boot (uses DWT cycle counter)
 static inline uint32_t micros(void) {
-    // Ensure DWT is enabled elsewhere; here we assume DWT->CYCCNT increments
-    return DWT->CYCCNT / (HAL_RCC_GetHCLKFreq() / 1000000U);
+    // DWT->CYCCNT increments at the core clock frequency. Using SystemCoreClock
+    // avoids errors if HCLK differs from the CPU speed.
+    return DWT->CYCCNT / (SystemCoreClock / 1000000U);
 }
 
 void RC_Input_Init(void) {


### PR DESCRIPTION
## Summary
- correct microsecond conversion in `RC_Input` by using `SystemCoreClock`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851e3d2cd4083308cbb810258c5d057