### PR TITLE
Fix pack voltage from PH2 ADC

### DIFF
--- a/Core/Inc/battery.h
+++ b/Core/Inc/battery.h
@@ -15,7 +15,7 @@
 /*
  * Battery & Power Management Driver
  *
- * - Call Battery_Init(&hi2c, shunt_ohm) once at startup.
+ * - Call Battery_Init(&hi2c, &hadc, shunt_ohm) once at startup.
  * - Regularly call Battery_Tick(now_ms) to integrate capacity.
  * - Use Battery_ReadPackVoltage() and Battery_ReadCurrent() to get live readings.
  * - Use Battery_GetRemaining_mAh() or Battery_GetRemainingPercent() for capacity.
@@ -24,8 +24,11 @@
 
 /// Initialize battery monitoring.
 ///   • hi2c: handle for I2C to INA219.
+///   • hadc: ADC handle for battery voltage measurement (e.g. PH2 channel).
 ///   • shuntOhm: value of the external shunt resistor in ohms.
-void       Battery_Init(I2C_HandleTypeDef *hi2c, float shuntOhm);
+void       Battery_Init(I2C_HandleTypeDef *hi2c,
+                        ADC_HandleTypeDef *hadc,
+                        float shuntOhm);
 
 /// Must be called periodically (e.g. in your 1 kHz tick or main loop).
 ///   • now_ms: HAL_GetTick() current time in ms.

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -227,7 +227,7 @@ int main(void)
   DebugMsg("RC input init done\r\n");
   Sonar_Init();      // e.g. HC‐SR04 trigger/echo with TIM3
   DebugMsg("Sonar init done\r\n");
-  Battery_Init(&hi2c1, Settings_GetINA219ShuntOhm());    // INA219 via I2C1, for measured load voltage/current
+  Battery_Init(&hi2c1, &hadc3, Settings_GetINA219ShuntOhm());    // INA219 via I2C1 and ADC3 on PH2
   DebugMsg("Battery init done\r\n");
 
   EKF_Init();              // your EKF/UKF library initialization


### PR DESCRIPTION
## Summary
- read the battery voltage using ADC3 on PH2
- store ADC handle during `Battery_Init`
- update initialization and header accordingly

## Testing
- `gcc -I Core/Inc -c Core/Src/battery.c -o /tmp/battery.o` *(fails: stm32h7xx_hal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68520bba00f083308205ab7d1ccccd80