### PR TITLE
Add BMP388 debug print and I2C scanner

### DIFF
--- a/Core/Inc/bmp388.h
+++ b/Core/Inc/bmp388.h
@@ -64,6 +64,9 @@ typedef struct {
  */
 bool BMP388_ReadCalibData(BMP388_CalibData *cdata);
 
+// Last detected I2C address (8-bit) used for communication
+extern uint8_t bmp388_i2c_addr;
+
 /** Initialize the sensor: detect address, reset, load calibration and configure. */
 bool BMP388_Init(void);
 


### PR DESCRIPTION
## Summary
- expose active BMP388 I2C address
- print chip ID and address when initializing the barometer
- add small I2C-bus scanner for debugging

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68520fb5fb2c833093e8f80ef07ce3a1