### PR TITLE
Add sonar and GPS debug menu options

### DIFF
--- a/Core/Inc/debug_menu.h
+++ b/Core/Inc/debug_menu.h
@@ -19,7 +19,9 @@ typedef enum {
     DEBUG_MENU_SENSORS = 0x01,
     DEBUG_MENU_PPM     = 0x02,
     DEBUG_MENU_BUZZER  = 0x04,
-    DEBUG_MENU_HELP    = 0x08
+    DEBUG_MENU_HELP    = 0x08,
+    DEBUG_MENU_SONAR   = 0x10,
+    DEBUG_MENU_GPS     = 0x20
 } DebugMenu_Mask;
 
 void DebugMenu_SetActionMask(uint8_t mask);


### PR DESCRIPTION
## Summary
- extend DebugMenu_Mask enum for SONAR and GPS bits
- display sonar and GPS options in debug menu
- implement sonar and GPS info handlers
- process sonar and GPS actions and commands

## Testing
- `gcc -std=c99 -c -I./Core/Inc Core/Src/debug_menu.c` *(fails: stm32h7xx_hal.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68522acf539483309d36e660e7fbd103