### PR TITLE
Improve sonar missing sensor detection

### DIFF
--- a/Core/Inc/sonar.h
+++ b/Core/Inc/sonar.h
@@ -21,6 +21,8 @@
  * - In HAL_GPIO_EXTI_Callback for each echo pin, call Sonar_EchoCallback(index, state).
  * - Call Sonar_TriggerAll() periodically (e.g. every 50ms) to send trigger pulses.
  * - Use Sonar_ReadDistance(index) to get the last measured distance (in meters).
+ *   A return value < 0 indicates no echo was received (sensor missing or out
+ *   of range).
  *
  *   Echo pins:   PF6, PF7, PF8
  *   Trigger pins: PF10, PF11, PF12


### PR DESCRIPTION
## Summary
- mark unresponsive sonar readings as invalid
- note invalid value behavior in `sonar.h`

## Testing
- `gcc -c Core/Src/sonar.c -ICore/Inc` *(fails: `stm32h7xx_hal.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535758a3948330b53bd2bcf107ff84