### PR TITLE
Fix sonar invalid value handling and update defaults

### DIFF
--- a/Core/Inc/sonar.h
+++ b/Core/Inc/sonar.h
@@ -21,8 +21,8 @@
  * - In HAL_GPIO_EXTI_Callback for each echo pin, call Sonar_EchoCallback(index, state).
  * - Call Sonar_TriggerAll() periodically (e.g. every 50ms) to send trigger pulses.
  * - Use Sonar_ReadDistance(index) to get the last measured distance (in meters).
- *   A return value < 0 indicates no echo was received (sensor missing or out
- *   of range).
+ *   If no echo was received (sensor missing or out of range), the function
+ *   returns 0 to indicate an invalid reading.
  *
  *   Echo pins:   PF6, PF7, PF8
  *   Trigger pins: PF10, PF11, PF12

--- a/Core/Src/settings.c
+++ b/Core/Src/settings.c
@@ -40,7 +40,8 @@ static float  baro_tolHpa          = 10.0f;
 static float  baro_altOffset       = 0.0f;
 
 static bool   sonar_enabled        = false;
-static float  sonar_maxDistance    = 6.0f;
+// Maximum range of the sonar in meters
+static float  sonar_maxDistance    = 4.0f;
 static float  sonar_minDistance    = 0.2f;
 static uint16_t sonar_updateRateHz = 10;
 static float  sonar_groundOffset   = 0.0f;

--- a/Core/Src/sonar.c
+++ b/Core/Src/sonar.c
@@ -3,7 +3,8 @@
 #include "main.h"  // for TRIGx pin definitions
 
 #define TRIG_PULSE_US    10   // 10 µs pulse
-#define MAX_DISTANCE_M   6.0f // 6 m max
+// Maximum measurable distance (meters)
+#define MAX_DISTANCE_M   4.0f // 4 m max
 #define SONAR_TIMEOUT_MS 40   // ~6 m round trip
 
 
@@ -83,7 +84,13 @@ void Sonar_EchoCallback(uint8_t index, GPIO_PinState state) {
 
 float Sonar_ReadDistance(uint8_t index) {
     if (index < SONAR_COUNT) {
-        return lastDistance[index];
+        float d = lastDistance[index];
+        // When no echo was received, distance is negative. Report zero
+        // to indicate an invalid or missing reading.
+        if (d < 0.0f) {
+            return 0.0f;
+        }
+        return d;
     }
-    return MAX_DISTANCE_M;
+    return 0.0f;
 }


### PR DESCRIPTION
## Summary
- adjust sonar max distance defaults to 4m
- return 0 when sonar has no reading
- clarify sonar header documentation

## Testing
- `gcc -ICore/Inc -fsyntax-only Core/Src/sonar.c` *(fails: stm32h7xx_hal.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68535b6dd1a48330aae9bd48430597c5