### PR TITLE
Fix BMP388 debug printf truncation

### DIFF
--- a/Core/Src/bmp388.c
+++ b/Core/Src/bmp388.c
@@ -199,7 +199,7 @@ bool BMP388_Init(void)
     // Print chip ID and detected address for debugging
     {
         uint8_t addr7 = bmp388_i2c_addr >> 1;
-        char msg[80];
+        char msg[96];
         int len = snprintf(msg, sizeof(msg),
             "BMP388 CHIP ID       = 0x%02X\r\n"
             "BMP388 I2C addr (7b) = 0x%02X\r\n"


### PR DESCRIPTION
## Summary
- resize the BMP388 debug message buffer to prevent truncation warning

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68565a6570f083308518c7b9f1429c1d