### PR TITLE
Increase BMP388 wait timeout

### DIFF
--- a/Core/Src/bmp388.c
+++ b/Core/Src/bmp388.c
@@ -158,7 +158,11 @@ bool BMP388_ReadOneShot(float *press, float *temp)
 {
     if (!BMP388_TriggerOneShot())
         return false;
-    if (!BMP388_WaitForData(10))
+    // Allow enough time for the conversion based on oversampling settings.
+    // The previous 10ms timeout was occasionally too short, leading to
+    // sporadic read failures. 25ms comfortably covers the worst case
+    // conversion time with the current configuration.
+    if (!BMP388_WaitForData(25))
         return false;
     int32_t ip, it;
     if (!BMP388_ReadPressureTempInt(&ip, &it))


### PR DESCRIPTION
## Summary
- increase barometer conversion wait time to 25ms

## Testing
- `gcc -c Core/Src/bmp388.c -I Core/Inc` *(fails: stm32h7xx_hal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68565e73e050833098e5c7f86bbfeb5c