### PR TITLE
Switch barometer to continuous mode

### DIFF
--- a/Core/Inc/baro.h
+++ b/Core/Inc/baro.h
@@ -14,7 +14,7 @@
 /*
  * BMP388 Barometer driver.
  * - Call Baro_Init(&hi2c1) once at startup.
- * - Call Baro_ReadPressure(&pressure_hPa) to get pressure in hPa (blocking ~5ms).
+ * - Call Baro_ReadPressure(&pressure_hPa) to get pressure in hPa.
  * - Call Baro_GetAltitude(&alt_m) to compute altitude from the last pressure and
  *   the sea-level reference from settings.
  */

--- a/Core/Inc/bmp388.h
+++ b/Core/Inc/bmp388.h
@@ -91,6 +91,15 @@ bool BMP388_WaitForData(uint32_t timeout_ms);
  */
 bool BMP388_ReadOneShot(float *pressure, float *temperature);
 
+/**
+ * @brief Reads the latest pressure and temperature sample when the sensor is
+ *        running in continuous mode.
+ * @param pressure Pointer to receive pressure in Pa.
+ * @param temperature Pointer to receive temperature in °C.
+ * @return true on success, false on I2C error or timeout.
+ */
+bool BMP388_ReadContinuous(float *pressure, float *temperature);
+
 // Raw and compensated access helpers
 bool    BMP388_ReadRaw(uint32_t *p, uint32_t *t);
 int64_t BMP388_CompensateTemperature(uint32_t uncomp_temperature);

--- a/Core/Src/baro.c
+++ b/Core/Src/baro.c
@@ -7,9 +7,11 @@ static I2C_HandleTypeDef *hi2c_baro;
 
 // Trigger + read blocking
 bool Baro_ReadPressure(float *pressure_hPa) {
-    // Trigger one-shot conversion and read compensated value
+    // Read a freshly updated sample from the barometer running in
+    // continuous mode.
     float p, t;
-    if (!BMP388_ReadOneShot(&p, &t)) return false;
+    if (!BMP388_ReadContinuous(&p, &t))
+        return false;
     *pressure_hPa = p; // already in hPa
     return true;
 }

--- a/Core/Src/bmp388.c
+++ b/Core/Src/bmp388.c
@@ -174,6 +174,23 @@ bool BMP388_ReadOneShot(float *press, float *temp)
     return true;
 }
 
+bool BMP388_ReadContinuous(float *press, float *temp)
+{
+    // Wait for a fresh measurement in normal mode. This mirrors the
+    // timeout used by the one-shot path, ensuring data is ready without
+    // blocking excessively.
+    if (!BMP388_WaitForData(25))
+        return false;
+    int32_t ip, it;
+    if (!BMP388_ReadPressureTempInt(&ip, &it))
+        return false;
+    if (press)
+        *press = (float)ip / 100.0f;      // Pa to hPa
+    if (temp)
+        *temp = (float)it / 100.0f;       // 0.01°C -> °C
+    return true;
+}
+
 static bool BMP388_Configure(void)
 {
     uint8_t osr = ((0x03 & BMP388_OSR_P_MASK) << BMP388_OSR_P_BIT) |


### PR DESCRIPTION
## Summary
- add `BMP388_ReadContinuous` helper
- switch `Baro_ReadPressure` to continuous reading
- document the new API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68565f5a00388330acf8acf378ddf76b