### PR TITLE
Fix root ground offset accumulation

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -1,0 +1,57 @@
+const DEFAULT_GROUND_SAMPLE_INTERVAL = 5;
+
+/**
+ * Updates the desired vertical offset that keeps the player's root aligned
+ * with the sampled ground height.
+ *
+ * @param {Object} state - Runtime locomotion state that stores the ground
+ *   alignment parameters.
+ * @param {BABYLON.TransformNode} playerRoot - Root transform for the
+ *   character that is being aligned.
+ * @param {(root: BABYLON.TransformNode) => number} sampleRootGroundOffset -
+ *   Callback that returns the delta between the desired ground height and the
+ *   current foot bottom position (desired - bottom).
+ */
+export function updateRootGroundOffset(
+  state,
+  playerRoot,
+  sampleRootGroundOffset
+) {
+  if (!state.grounded) {
+    return;
+  }
+
+  if (state.groundSampleCountdown > 0) {
+    state.groundSampleCountdown -= 1;
+  }
+
+  if (!state.groundSampleDirty && state.groundSampleCountdown > 0) {
+    return;
+  }
+
+  playerRoot.computeWorldMatrix(true);
+  const sampleOffset = sampleRootGroundOffset(playerRoot);
+  if (Number.isFinite(sampleOffset)) {
+    state.rootGroundOffsetTarget += sampleOffset;
+  }
+
+  state.groundSampleDirty = false;
+  state.groundSampleCountdown =
+    state.groundSampleInterval ?? DEFAULT_GROUND_SAMPLE_INTERVAL;
+}
+
+/**
+ * Smooths the vertical offset that is applied to the player's root so the
+ * adjustment converges gradually toward the sampled target.
+ *
+ * @param {Object} state - Locomotion state containing the offsets.
+ */
+export function applyRootGroundOffsetSmoothing(state) {
+  const lerp = state.rootGroundOffsetLerp ?? 0;
+  if (lerp <= 0) {
+    return;
+  }
+
+  const targetDelta = state.rootGroundOffsetTarget - state.rootGroundOffset;
+  state.rootGroundOffset += targetDelta * lerp;
+}


### PR DESCRIPTION
## Summary
- add a ground-alignment helper that samples the root height and accumulates the delta on the target offset
- provide smoothing helper to ease the target offset toward the current offset each frame

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e05e8fd5fc8330b4b63471fca0abc0