### PR TITLE
Fix root ground offset target accumulation

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -32,7 +32,8 @@ export function updateRootGroundOffset(
   playerRoot.computeWorldMatrix(true);
   const sampleOffset = sampleRootGroundOffset(playerRoot);
   if (Number.isFinite(sampleOffset)) {
-    state.rootGroundOffsetTarget += sampleOffset;
+    const currentOffset = state.rootGroundOffset ?? 0;
+    state.rootGroundOffsetTarget = currentOffset + sampleOffset;
   }
 
   state.groundSampleDirty = false;


### PR DESCRIPTION
## Summary
- base the root ground offset target on the current applied offset so repeated samples do not over-correct

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e06758d34883309345ef9c3efa6efb