### PR TITLE
Ensure menu background is disposed on mode transitions and add scene audit HUD

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -56,3 +56,347 @@ export function applyRootGroundOffsetSmoothing(state) {
   const targetDelta = state.rootGroundOffsetTarget - state.rootGroundOffset;
   state.rootGroundOffset += targetDelta * lerp;
 }
+
+export const GameMode = Object.freeze({
+  MENU: "menu",
+  GAME: "game",
+  CREATOR: "creator",
+  RIG: "rig",
+});
+
+function collectSceneCounts(scene) {
+  if (!scene || scene.isDisposed()) {
+    return { nodes: 0, materials: 0, textures: 0 };
+  }
+
+  const nodes = scene.getNodes ? scene.getNodes().length : 0;
+  const materials = scene.materials?.length ?? 0;
+  const textures = scene.textures?.length ?? 0;
+
+  return { nodes, materials, textures };
+}
+
+class MenuBackground {
+  /**
+   * @param {BABYLON.Scene} scene
+   */
+  constructor(scene) {
+    this.scene = scene;
+    this.root = new BABYLON.TransformNode("menuBackgroundRoot", scene);
+
+    this.light = new BABYLON.HemisphericLight(
+      "menuBackgroundLight",
+      new BABYLON.Vector3(0.15, 1, 0.25),
+      scene
+    );
+    this.light.intensity = 0.8;
+    this.light.parent = this.root;
+
+    this.mesh = BABYLON.MeshBuilder.CreateSphere(
+      "menuBackgroundSky",
+      { diameter: 50, sideOrientation: BABYLON.Mesh.BACKSIDE },
+      scene
+    );
+    this.mesh.parent = this.root;
+
+    this.material = new BABYLON.StandardMaterial(
+      "menuBackgroundMaterial",
+      scene
+    );
+    this.material.backFaceCulling = false;
+    this.material.disableLighting = true;
+
+    this.texture = new BABYLON.DynamicTexture(
+      "menuBackgroundTexture",
+      { width: 512, height: 512 },
+      scene,
+      false
+    );
+    this.texture.hasAlpha = false;
+
+    const ctx = this.texture.getContext();
+    const gradient = ctx.createLinearGradient(0, 0, 0, 512);
+    gradient.addColorStop(0, "#1f3e86");
+    gradient.addColorStop(0.45, "#0f1d3c");
+    gradient.addColorStop(1, "#040810");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, 512, 512);
+
+    ctx.font = "48px 'Segoe UI', sans-serif";
+    ctx.fillStyle = "rgba(255, 255, 255, 0.12)";
+    ctx.fillText("Hawk-H7 Systems", 40, 120);
+    ctx.font = "22px 'Segoe UI', sans-serif";
+    ctx.fillStyle = "rgba(255, 255, 255, 0.25)";
+    ctx.fillText("Menu Background", 40, 170);
+    this.texture.update();
+
+    this.material.diffuseTexture = this.texture;
+    this.mesh.material = this.material;
+
+    this._rotationObserver = scene.onBeforeRenderObservable.add(() => {
+      if (!this.root || this.root.isDisposed()) {
+        return;
+      }
+
+      const delta = scene.getEngine().getDeltaTime();
+      const radians = (delta / 1000) * Math.PI * 0.025;
+      this.root.rotate(BABYLON.Axis.Y, radians, BABYLON.Space.WORLD);
+    });
+
+    this._pulseInterval = window.setInterval(() => {
+      if (!this.light || this.light.isDisposed()) {
+        return;
+      }
+      this.light.intensity = 0.65 + Math.random() * 0.25;
+    }, 1600);
+
+    this._domAnchor =
+      document.getElementById("render-root") ?? document.body;
+    this._domRoot = document.createElement("div");
+    this._domRoot.className = "menu-decor";
+    this._domRoot.textContent = "Menu background active";
+    this._domAnchor.appendChild(this._domRoot);
+
+    this._sceneDisposeObserver = scene.onDisposeObservable.add(() => {
+      this.dispose();
+    });
+
+    this._disposed = false;
+  }
+
+  dispose() {
+    if (this._disposed) {
+      return;
+    }
+    this._disposed = true;
+
+    if (this._sceneDisposeObserver) {
+      this.scene?.onDisposeObservable.remove(this._sceneDisposeObserver);
+      this._sceneDisposeObserver = null;
+    }
+
+    if (this._rotationObserver) {
+      this.scene?.onBeforeRenderObservable.remove(this._rotationObserver);
+      this._rotationObserver = null;
+    }
+
+    if (this._pulseInterval != null) {
+      window.clearInterval(this._pulseInterval);
+      this._pulseInterval = null;
+    }
+
+    this._domRoot?.remove();
+    this._domRoot = null;
+    this._domAnchor = null;
+
+    this.texture?.dispose();
+    this.texture = null;
+
+    this.material?.dispose();
+    this.material = null;
+
+    this.mesh?.dispose();
+    this.mesh = null;
+
+    this.light?.dispose();
+    this.light = null;
+
+    this.root?.dispose();
+    this.root = null;
+
+    this.scene = null;
+  }
+}
+
+class ExperienceController {
+  /**
+   * @param {HTMLCanvasElement} canvas
+   * @param {{ recordTransition: Function } | null} auditPanel
+   */
+  constructor(canvas, auditPanel) {
+    if (!canvas) {
+      throw new Error("A canvas is required to initialize the experience");
+    }
+
+    this.canvas = canvas;
+    this.engine = new BABYLON.Engine(canvas, true, {
+      preserveDrawingBuffer: true,
+      stencil: true,
+    });
+    this.auditPanel = auditPanel ?? null;
+    this.currentMode = null;
+    this.scene = null;
+    this.menuBackground = null;
+
+    this._renderLoop = this._renderLoop.bind(this);
+    this.engine.runRenderLoop(this._renderLoop);
+
+    this._resizeHandler = () => {
+      this.engine.resize();
+    };
+    window.addEventListener("resize", this._resizeHandler);
+  }
+
+  _renderLoop() {
+    if (this.scene && !this.scene.isDisposed()) {
+      this.scene.render();
+    }
+  }
+
+  _createBaseScene() {
+    const scene = new BABYLON.Scene(this.engine);
+    scene.clearColor = new BABYLON.Color4(0.025, 0.032, 0.07, 1);
+
+    const camera = new BABYLON.ArcRotateCamera(
+      "camera",
+      Math.PI / 2,
+      Math.PI / 2.2,
+      8,
+      BABYLON.Vector3.Zero(),
+      scene
+    );
+    camera.attachControl(this.canvas, true);
+    camera.lowerRadiusLimit = 4;
+    camera.upperRadiusLimit = 20;
+
+    new BABYLON.HemisphericLight(
+      "sceneLight",
+      new BABYLON.Vector3(0.1, 1, 0.3),
+      scene
+    ).intensity = 0.85;
+
+    const ground = BABYLON.MeshBuilder.CreateGround(
+      "ground",
+      { width: 18, height: 18 },
+      scene
+    );
+    const groundMaterial = new BABYLON.StandardMaterial("groundMaterial", scene);
+    groundMaterial.diffuseColor = new BABYLON.Color3(0.1, 0.16, 0.22);
+    groundMaterial.specularColor = new BABYLON.Color3(0, 0, 0);
+    ground.material = groundMaterial;
+
+    return scene;
+  }
+
+  _populateModeContent(scene, mode) {
+    const colorMap = {
+      [GameMode.MENU]: new BABYLON.Color3(0.45, 0.65, 1),
+      [GameMode.GAME]: new BABYLON.Color3(0.6, 0.86, 0.4),
+      [GameMode.CREATOR]: new BABYLON.Color3(0.94, 0.74, 0.4),
+      [GameMode.RIG]: new BABYLON.Color3(0.94, 0.45, 0.55),
+    };
+
+    const mesh = BABYLON.MeshBuilder.CreateBox(
+      `${mode}Marker`,
+      { size: 1.2 },
+      scene
+    );
+    mesh.position.y = 1.1;
+    mesh.material = new BABYLON.StandardMaterial(`${mode}Material`, scene);
+    mesh.material.diffuseColor = colorMap[mode] ?? BABYLON.Color3.White();
+
+    const label = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI(
+      `${mode}LabelUI`,
+      true,
+      scene
+    );
+
+    const panel = new BABYLON.GUI.StackPanel();
+    panel.isVertical = true;
+    panel.width = "220px";
+    panel.horizontalAlignment = BABYLON.GUI.Control.HORIZONTAL_ALIGNMENT_RIGHT;
+    panel.verticalAlignment = BABYLON.GUI.Control.VERTICAL_ALIGNMENT_TOP;
+    panel.paddingRight = "24px";
+    panel.paddingTop = "24px";
+
+    const textBlock = new BABYLON.GUI.TextBlock();
+    textBlock.text = `${mode.toUpperCase()} MODE`;
+    textBlock.color = "#dde7ff";
+    textBlock.fontSize = 18;
+    textBlock.fontStyle = "bold";
+
+    panel.addControl(textBlock);
+    label.addControl(panel);
+
+    return {
+      mesh,
+      label,
+    };
+  }
+
+  setMode(mode) {
+    if (!Object.values(GameMode).includes(mode)) {
+      throw new Error(`Unknown mode: ${mode}`);
+    }
+
+    if (this.currentMode === mode) {
+      return;
+    }
+
+    const previousScene = this.scene;
+    const preCounts = collectSceneCounts(previousScene);
+
+    if (this.menuBackground) {
+      this.menuBackground.dispose();
+      this.menuBackground = null;
+    }
+
+    if (previousScene && !previousScene.isDisposed()) {
+      previousScene.dispose();
+    }
+
+    const scene = this._createBaseScene();
+    const { label } = this._populateModeContent(scene, mode);
+
+    if (mode === GameMode.MENU) {
+      this.menuBackground = new MenuBackground(scene);
+    }
+
+    this.scene = scene;
+
+    const finalizeRecord = () => {
+      const postCounts = collectSceneCounts(scene);
+      this.auditPanel?.recordTransition(this.currentMode, mode, preCounts, postCounts);
+    };
+
+    if (scene.isReady()) {
+      finalizeRecord();
+    } else {
+      scene.executeWhenReady(finalizeRecord);
+    }
+
+    this.currentMode = mode;
+
+    scene.onDisposeObservable.add(() => {
+      label.dispose();
+    });
+  }
+
+  dispose() {
+    if (this.menuBackground) {
+      this.menuBackground.dispose();
+      this.menuBackground = null;
+    }
+
+    if (this.scene && !this.scene.isDisposed()) {
+      this.scene.dispose();
+    }
+
+    this.engine.stopRenderLoop(this._renderLoop);
+    this.engine.dispose();
+    window.removeEventListener("resize", this._resizeHandler);
+  }
+}
+
+/**
+ * Bootstraps the Babylon.js experience and returns a controller that can
+ * change modes.
+ *
+ * @param {HTMLCanvasElement} canvas
+ * @param {{ recordTransition: Function } | null} auditPanel
+ */
+export function initializeExperience(canvas, auditPanel = null) {
+  const controller = new ExperienceController(canvas, auditPanel);
+  controller.setMode(GameMode.MENU);
+  return controller;
+}

--- a/web/hud.js
+++ b/web/hud.js
@@ -1,0 +1,82 @@
+/**
+ * Simple QA panel that records scene resource counts before and after
+ * transitions. The panel renders to the provided host node.
+ */
+export class SceneAuditPanel {
+  /**
+   * @param {HTMLElement} host
+   */
+  constructor(host) {
+    if (!host) {
+      throw new Error("SceneAuditPanel host element is required");
+    }
+
+    this._host = host;
+    this._tableBody = document.createElement("tbody");
+    this._rows = [];
+
+    const heading = document.createElement("h2");
+    heading.textContent = "Scene Audit";
+
+    const description = document.createElement("p");
+    description.textContent =
+      "Tracks Babylon.js resources before and after each mode switch to catch leaks.";
+    description.style.marginTop = "0";
+    description.style.marginBottom = "12px";
+    description.style.fontSize = "0.75rem";
+    description.style.opacity = "0.75";
+
+    const table = document.createElement("table");
+    table.className = "audit-table";
+
+    const header = document.createElement("thead");
+    header.innerHTML = `
+      <tr>
+        <th>From → To</th>
+        <th>Nodes</th>
+        <th>Materials</th>
+        <th>Textures</th>
+      </tr>
+    `;
+
+    table.append(header, this._tableBody);
+    host.append(heading, description, table);
+  }
+
+  /**
+   * Records a transition in the panel.
+   *
+   * @param {string | null} fromMode
+   * @param {string} toMode
+   * @param {{ nodes: number, materials: number, textures: number }} preCounts
+   * @param {{ nodes: number, materials: number, textures: number }} postCounts
+   */
+  recordTransition(fromMode, toMode, preCounts, postCounts) {
+    const transition = `${fromMode ?? "—"} → ${toMode}`;
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td class="mode">${transition}</td>
+      <td>${preCounts.nodes} → ${postCounts.nodes}</td>
+      <td>${preCounts.materials} → ${postCounts.materials}</td>
+      <td>${preCounts.textures} → ${postCounts.textures}</td>
+    `;
+
+    this._rows.push(row);
+    this._tableBody.appendChild(row);
+
+    if (this._rows.length > 10) {
+      const removed = this._rows.shift();
+      removed?.remove();
+    }
+  }
+}
+
+/**
+ * Convenience helper for creating the panel with minimal ceremony.
+ *
+ * @param {HTMLElement} host
+ * @returns {SceneAuditPanel}
+ */
+export function createHUD(host) {
+  return new SceneAuditPanel(host);
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Hawk-H7 QA Playground</title>
+    <style>
+      :root {
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        color-scheme: dark;
+        background: #10131a;
+        color: #eef2ff;
+      }
+
+      body,
+      html {
+        margin: 0;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+
+      #app {
+        flex: 1;
+        display: grid;
+        grid-template-columns: minmax(240px, 300px) 1fr;
+        grid-template-rows: 1fr;
+        gap: 0;
+        overflow: hidden;
+      }
+
+      #hud-root {
+        background: linear-gradient(160deg, rgba(36, 44, 64, 0.8), rgba(12, 16, 28, 0.9));
+        border-right: 1px solid rgba(255, 255, 255, 0.08);
+        display: flex;
+        flex-direction: column;
+        padding: 16px;
+        gap: 16px;
+        box-sizing: border-box;
+        backdrop-filter: blur(12px);
+      }
+
+      #render-root {
+        position: relative;
+        background: radial-gradient(circle at top, #0d1b2a, #000611);
+      }
+
+      #renderCanvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .mode-buttons {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 8px;
+      }
+
+      .mode-button {
+        appearance: none;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(14, 21, 35, 0.85);
+        color: inherit;
+        padding: 10px 12px;
+        border-radius: 8px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        cursor: pointer;
+        transition: background 120ms ease, transform 120ms ease,
+          border-color 120ms ease;
+      }
+
+      .mode-button:hover,
+      .mode-button:focus {
+        background: rgba(46, 88, 255, 0.2);
+        border-color: rgba(100, 160, 255, 0.45);
+        outline: none;
+      }
+
+      .mode-button[aria-pressed="true"] {
+        background: rgba(70, 120, 255, 0.3);
+        border-color: rgba(125, 180, 255, 0.75);
+      }
+
+      .panel {
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 12px;
+        padding: 12px;
+        background: rgba(9, 13, 24, 0.7);
+        box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+      }
+
+      .panel h2 {
+        margin: 0 0 12px;
+        font-size: 1rem;
+      }
+
+      .audit-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+      }
+
+      .audit-table thead {
+        text-transform: uppercase;
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+        color: rgba(223, 231, 255, 0.65);
+      }
+
+      .audit-table th,
+      .audit-table td {
+        text-align: left;
+        padding: 6px 4px;
+      }
+
+      .audit-table tbody tr:nth-child(odd) {
+        background: rgba(255, 255, 255, 0.04);
+      }
+
+      .audit-table tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.02);
+      }
+
+      .audit-table tbody td.mode {
+        font-weight: 600;
+        color: rgba(189, 208, 255, 0.9);
+      }
+
+      .menu-decor {
+        position: absolute;
+        inset: 16px;
+        border-radius: 24px;
+        pointer-events: none;
+        border: 2px dashed rgba(118, 160, 255, 0.35);
+        opacity: 0.7;
+        display: flex;
+        align-items: flex-start;
+        justify-content: flex-end;
+        padding: 12px 16px;
+        font-size: 0.9rem;
+        color: rgba(173, 202, 255, 0.8);
+      }
+    </style>
+    <script src="https://cdn.babylonjs.com/babylon.js" defer></script>
+    <script src="https://cdn.babylonjs.com/gui/babylon.gui.min.js" defer></script>
+    <script type="module" defer>
+      import { initializeExperience, GameMode } from "./game.js";
+      import { createHUD } from "./hud.js";
+
+      window.addEventListener("DOMContentLoaded", () => {
+        const canvas = document.getElementById("renderCanvas");
+        const auditHost = document.getElementById("audit-panel");
+        const auditPanel = createHUD(auditHost);
+        const experience = initializeExperience(canvas, auditPanel);
+
+        const buttons = document.querySelectorAll("[data-mode]");
+        function updatePressed(targetMode) {
+          buttons.forEach((button) => {
+            button.setAttribute(
+              "aria-pressed",
+              button.dataset.mode === targetMode ? "true" : "false"
+            );
+          });
+        }
+
+        buttons.forEach((button) => {
+          button.addEventListener("click", () => {
+            const mode = button.dataset.mode;
+            experience.setMode(mode);
+            updatePressed(mode);
+          });
+        });
+
+        updatePressed(GameMode.MENU);
+      });
+    </script>
+  </head>
+  <body>
+    <div id="app">
+      <aside id="hud-root">
+        <section class="panel">
+          <h2>Modes</h2>
+          <div class="mode-buttons">
+            <button class="mode-button" data-mode="menu" aria-pressed="true">
+              Menu
+            </button>
+            <button class="mode-button" data-mode="game" aria-pressed="false">
+              Game
+            </button>
+            <button class="mode-button" data-mode="creator" aria-pressed="false">
+              Creator
+            </button>
+            <button class="mode-button" data-mode="rig" aria-pressed="false">
+              Rig Editor
+            </button>
+          </div>
+        </section>
+        <section id="audit-panel" class="panel"></section>
+      </aside>
+      <main id="render-root">
+        <canvas id="renderCanvas"></canvas>
+      </main>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Babylon.js QA playground with mode controls and styling
- implement menu background lifecycle management with explicit disposal on scene changes
- introduce a scene audit HUD that reports Babylon resource counts across transitions

## Testing
- Manual quickcheck: python -m http.server 8000, then navigate to http://127.0.0.1:8000/index.html and swap between Menu, Game, Creator, and Rig Editor modes

------
https://chatgpt.com/codex/tasks/task_e_68e06eac8fd483308299f0cb0d495ed1